### PR TITLE
template form actions, us sms bug fix

### DIFF
--- a/lib/MyStack.ts
+++ b/lib/MyStack.ts
@@ -15,6 +15,10 @@ export default class MyStack extends sst.Stack {
       this,
       '/codemarket/default/senderEmail',
     );
+    const SNS_ORIGINAL_NUMBER = StringParameter.valueForStringParameter(
+      this,
+      '/codemarket/sns/originalNumber',
+    );
     const USER_POOL_ID = StringParameter.valueForStringParameter(this, '/vijaa/userpoolId');
     const userPol = UserPool.fromUserPoolId(this, 'UserPool', USER_POOL_ID);
 
@@ -46,12 +50,11 @@ export default class MyStack extends sst.Stack {
           SENDER_EMAIL: SENDER_EMAIL || '',
           DATABASE: `mongodb+srv://${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}@codemarket-staging.k16z7.mongodb.net/${scope.stage}?retryWrites=true&w=majority`,
           USER_POOL_ID: USER_POOL_ID,
-          GRAPHQL_API_URL: process.env.GRAPHQL_API_URL || 'old',
+          SNS_ORIGINAL_NUMBER: SNS_ORIGINAL_NUMBER,
+          GRAPHQL_API_URL: process.env.GRAPHQL_API_URL || '',
           GRAPHQL_API_KEY: process.env.GRAPHQL_API_KEY || '',
           ONESIGNAL_API_KEY: process.env.ONESIGNAL_API_KEY || '',
           ONESIGNAL_APP_ID: process.env.ONESIGNAL_APP_ID || '',
-          TWILIO_ACCOUNT_SID: process.env.TWILIO_ACCOUNT_SID || '',
-          TWILIO_AUTH_TOKEN: process.env.TWILIO_AUTH_TOKEN || '',
         },
       },
       dataSources: dataSources,

--- a/src/form/index.ts
+++ b/src/form/index.ts
@@ -176,8 +176,14 @@ export const handler = async (event: AppSyncEvent): Promise<any> => {
         response = await response.populate(responsePopulate).execPopulate();
         // Run Actions
         if (!(process.env.NODE_ENV === 'test')) {
-          const form = await FormModel.findById(response.formId);
-          await runFormActions(response, form, args?.options?.actions);
+          const form: any = await FormModel.findById(response.formId);
+          await runFormActions(response, {
+            ...form,
+            settings: {
+              ...form.settings,
+              actions: args?.options?.actions || form.settings?.actions,
+            },
+          });
           await sendResponseNotification(form, response);
         }
         return response;

--- a/src/form/utils/actions.ts
+++ b/src/form/utils/actions.ts
@@ -2,7 +2,7 @@ import { sendEmail } from '../../utils/email';
 import { User } from '../../user/utils/userModel';
 import { sendSms } from '../../utils/sms';
 
-export const runFormActions = async (response, form, actions?: any) => {
+export const runFormActions = async (response, form) => {
   if (form?.settings?.actions?.length > 0) {
     form?.settings?.actions?.forEach(async (action) => {
       if (

--- a/src/utils/sms.ts
+++ b/src/utils/sms.ts
@@ -1,5 +1,7 @@
 import * as AWS from 'aws-sdk';
 
+const { SNS_ORIGINAL_NUMBER = '' } = process.env;
+
 const sns = new AWS.SNS({ region: 'us-east-1', apiVersion: '2010-03-31' });
 
 interface Payload {
@@ -8,9 +10,20 @@ interface Payload {
 }
 
 export const sendSms = (payload: Payload) => {
-  const params = {
+  let params: any = {
     Message: payload.body,
     PhoneNumber: payload.phoneNumber,
   };
+  if (payload.phoneNumber.includes('+1') && SNS_ORIGINAL_NUMBER) {
+    params = {
+      ...params,
+      MessageAttributes: {
+        ['AWS.SNS.SMS.OriginationNumber']: {
+          DataType: 'String',
+          StringValue: SNS_ORIGINAL_NUMBER,
+        },
+      },
+    };
+  }
   return sns.publish(params).promise();
 };


### PR DESCRIPTION

if form actions are overridden at template then run those actions.

Added Original number argument to sns payload to send sms in us
[https://docs.aws.amazon.com/sns/latest/dg/channels-sms-us-requirements.html](https://docs.aws.amazon.com/sns/latest/dg/channels-sms-us-requirements.html)








